### PR TITLE
Db regex fixes

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -15,7 +15,7 @@ module "api" {
   subdomain_name   = "api"
 
   django_cors_origin_whitelist = ["https://multinet.app", "https://multimatrix.multinet.app", "https://multilink.multinet.app", "https://multidynamic.multinet.app", "https://vdl.sci.utah.edu"]
-  django_cors_origin_regex_whitelist = ["^https:\\/\\/deploy-preview-[0-9a-z\\-]+--next-multinet-client\\.netlify\\.app$", "^https:\\/\\/deploy-preview-[0-9a-z\\-]+--next-multimatrix\\.netlify\\.app$", "^https:\\/\\/deploy-preview-[0-9a-z\\-]+--next-multilink\\.netlify\\.app$"]
+  django_cors_origin_regex_whitelist = ["^https:\\/\\/deploy-preview-[0-9a-z\\-]+--multinet-client\\.netlify\\.app$", "^https:\\/\\/deploy-preview-[0-9a-z\\-]+--multimatrix\\.netlify\\.app$", "^https:\\/\\/deploy-preview-[0-9a-z\\-]+--next-multilink\\.netlify\\.app$", "^https:\\/\\/deploy-preview-[0-9a-z\\-]+--multidynamic\\.netlify\\.app$"]
   
 
   additional_sensitive_django_vars = {

--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -8,13 +8,6 @@ resource "aws_route53_record" "db" {
   name    = "db.multinet.app"
   type    = "CNAME"
   ttl     = "300"
-  records = ["ec2-3-22-105-197.us-east-2.compute.amazonaws.com"]
-}
-resource "aws_route53_record" "db-testing" {
-  zone_id = aws_route53_zone.multinet.zone_id
-  name    = "db-testing.multinet.app"
-  type    = "CNAME"
-  ttl     = "300"
   records = ["ec2-3-14-123-189.us-east-2.compute.amazonaws.com"]
 }
 


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
I noticed that we we're still using db-testing for the db address. I've pointed db at what used to be db-testing so we can use that route. db-testing will be free for reuse after this. 

Additionally, I've updated the server to use arangodb 3.8, the current version. It seemed to upgrade with no issues.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] Set up certbot to use db.multinet.app
- [ ] Make certbot forget db-testing.multinet.app